### PR TITLE
[15.0][IMP] mis_builder_total_committed_purchase : add product column in the MIS report

### DIFF
--- a/mis_builder_total_committed_purchase/data/mis_total_committed_purchase.sql
+++ b/mis_builder_total_committed_purchase/data/mis_total_committed_purchase.sql
@@ -22,6 +22,8 @@ CREATE OR REPLACE VIEW mis_total_committed_purchase AS (
         pol.name AS name,
         po.date_planned::date as date,
         pol.account_analytic_id as analytic_account_id,
+        pol.product_id as product_id,
+        pol.order_id as purchase_order_id,
         pol.id AS res_id,
         'purchase.order.line' AS res_model,
         CASE

--- a/mis_builder_total_committed_purchase/i18n/mis_builder_total_committed_purchase.pot
+++ b/mis_builder_total_committed_purchase/i18n/mis_builder_total_committed_purchase.pot
@@ -4,8 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 15.0\n"
+"Project-Id-Version: Odoo Server 15.0+e\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-11-24 11:10+0000\n"
+"PO-Revision-Date: 2022-11-24 11:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -71,4 +73,9 @@ msgstr ""
 #. module: mis_builder_total_committed_purchase
 #: model:ir.model.fields,field_description:mis_builder_total_committed_purchase.field_mis_total_committed_purchase__name
 msgid "Name"
+msgstr ""
+
+#. module: mis_builder_total_committed_purchase
+#: model:ir.model.fields,field_description:mis_builder_total_committed_purchase.field_mis_total_committed_purchase__product_id
+msgid "Product"
 msgstr ""

--- a/mis_builder_total_committed_purchase/models/mis_total_committed_purchase.py
+++ b/mis_builder_total_committed_purchase/models/mis_total_committed_purchase.py
@@ -16,8 +16,10 @@ class MisTotalCommittedPurchase(models.Model):
     analytic_account_id = fields.Many2one(
         comodel_name="account.analytic.account", string="Analytic Account"
     )
-    account_id = fields.Many2one(comodel_name="account.account", string="Account")
-    company_id = fields.Many2one(comodel_name="res.company", string="Company")
+    account_id = fields.Many2one(comodel_name="account.account")
+    company_id = fields.Many2one(comodel_name="res.company")
+    product_id = fields.Many2one(comodel_name="product.product")
+    purchase_order_id = fields.Many2one(comodel_name="purchase.order")
     credit = fields.Float()
     debit = fields.Float()
     date = fields.Date()

--- a/mis_builder_total_committed_purchase/readme/HISTORY.rst
+++ b/mis_builder_total_committed_purchase/readme/HISTORY.rst
@@ -1,3 +1,10 @@
+15.0.1.0.1 (2022-11-24)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+**Features**
+
+- Add the product_id to the mis_builder_total_committed_purchase.
+
 15.0.1.0.0 (2022-08-30)
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/mis_builder_total_committed_purchase/views/mis_total_committed_purchase.xml
+++ b/mis_builder_total_committed_purchase/views/mis_total_committed_purchase.xml
@@ -9,6 +9,7 @@
             <tree>
                 <field name="date" />
                 <field name="name" />
+                <field name="purchase_order_id" />
                 <field name="account_id" />
                 <field
                     name="analytic_account_id"
@@ -19,6 +20,7 @@
                     widget="many2many_tags"
                     groups="analytic.group_analytic_tags"
                 />
+                <field name="product_id" />
                 <field name="debit" />
                 <field name="credit" />
             </tree>


### PR DESCRIPTION
- [x] Depends on https://github.com/OCA/mis-builder-contrib/pull/33 to fix pre-commit 

We want to be able to see the related product (and to filter on it) and the related purchase order when we display a MIS report using the MIS Total Purchase Commitment